### PR TITLE
test: ConvertCurrencyUseCase 단위 테스트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 local.properties
 
 .idea/gradle.xml
+
+.idea/codeStyles/codeStyleConfig.xml
+
+.idea/codeStyles/Project.xml

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -11,3 +11,17 @@ kotlin {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
+
+dependencies {
+    testImplementation(libs.junit5.api)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit5.engine)
+    testImplementation(libs.mockk)
+    testImplementation(libs.coroutinesTest)
+    implementation("javax.inject:javax.inject:1")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/domain/src/test/java/com/example/domain/usecase/ConvertCurrencyUseCaseTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/ConvertCurrencyUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.example.domain.usecase
+
+import com.example.domain.model.ConversionResult
+import com.example.domain.model.Currency
+import com.example.domain.repository.CurrencyRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkClass
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ConvertCurrencyUseCaseTest {
+    private lateinit var currencyRepository: CurrencyRepository
+    private lateinit var convertCurrencyUseCase: ConvertCurrencyUseCase
+
+    @BeforeEach
+    fun setUp() {
+        currencyRepository = mockk<CurrencyRepository>()
+        convertCurrencyUseCase = ConvertCurrencyUseCase(currencyRepository)
+
+        coEvery { currencyRepository.getCurrency("KRW") } returns Currency("KRW", "한국 원", 1512.28)
+        coEvery { currencyRepository.getCurrency("JPY") } returns Currency("JPY", "일본 엔", 159.50)
+        coEvery { currencyRepository.getCurrency("123") } returns null
+        coEvery { currencyRepository.saveConversionResult(any()) } just Runs
+    }
+
+    @Test
+    fun convertSuccess() = runTest {
+        val result = convertCurrencyUseCase.convert("KRW", 2000.0, "JPY")
+        val expect = ConversionResult(
+            fromCode = "KRW",
+            fromName = "한국 원",
+            fromAmount = 2000.0,
+            toCode = "JPY",
+            toName = "일본 엔",
+            toAmount = 210.9397730578993
+        )
+        assertEquals(expect.toAmount, result.getOrNull()!!.toAmount, 1e-6)
+        coVerify { currencyRepository.saveConversionResult(any()) }
+    }
+
+    @Test
+    fun convertFailureNoFromCode() = runTest {
+        val result = convertCurrencyUseCase.convert("123", 2000.0, "JPY")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun convertFailureNoToCode() = runTest {
+        val result = convertCurrencyUseCase.convert("KRW", 2000.0, "123")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!! is IllegalArgumentException)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,10 @@ composeBom = "2024.09.00"
 jetbrainsKotlinJvm = "2.2.10"
 hilt = "2.59.2"
 ksp = "2.2.10-2.0.2"
+junit5 = "5.10.2"
+mockk = "1.13.12"
+coroutinesTest = "1.8.1"
+junitJupiter = "5.14.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +33,11 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+junit5-api = {group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref="junit5"}
+junit5-engine = {group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref="junit5"}
+mockk = { module="io.mockk:mockk", version.ref="mockk"}
+coroutinesTest = {module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref="coroutinesTest"}
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 개요
- domain 모듈 테스트를 위한 프로젝트 세팅
- ConvertCurrencyUseCase 단위 테스트 구현 (junit5 + mockk)

## 변경 사항
- domain 모듈에 junit5, mockk, coroutine test 의존성 추가
- ConvertCurrencyUseCaseTest: ConvertCurrencyUseCase 유즈케이스에 대한 단위 테스트 구현

## 관련 이슈
Closes #6 