### PR TITLE
chore: Kover 커버리지 세팅 및 불필요한 도메인 클래스 삭제

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kover) apply false
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("java-library")
     alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.kover)
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/domain/src/main/java/com/example/domain/domain.kt
+++ b/domain/src/main/java/com/example/domain/domain.kt
@@ -1,4 +1,0 @@
-package com.example.domain
-
-class domain {
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ junit5 = "5.10.2"
 mockk = "1.13.12"
 coroutinesTest = "1.8.1"
 junitJupiter = "5.14.0"
+kover = "0.9.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -46,3 +47,4 @@ jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrai
 android-library = { id = "com.android.library", version.ref = "agp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
## 개요
테스트 커버리지 측정을 위한 Kover 의존성 추가
기존 구현한 ConvertCurrencyUseCaseTest 커버리지 측정 결과: 100%

## 변경 사항
- 전역 프로젝트에 kover 플러그인 추가
- domain 모듈에 kover 플러그인 추가
- domain 모듈 생성시 같이 생성된 도메인 클래스 삭제

## 관련 이슈
Closes #6 